### PR TITLE
Add sample Vue dashboard components

### DIFF
--- a/flask-vue-multiagent-demo/frontend/src/App.vue
+++ b/flask-vue-multiagent-demo/frontend/src/App.vue
@@ -1,50 +1,60 @@
 <template>
-  <div class="chat-container">
-    <h1>Multi-Agent Chat</h1>
-    <div class="messages">
-      <div
-        v-for="msg in messages"
-        :key="msg.id"
-        :class="['message', msg.from === 'user' ? 'user' : 'agent']"
-      >
-        <div v-if="msg.from !== 'user'" class="bubble agent">
-          <div class="agent-header">
-            <img :src="`/${msg.from}.svg`" alt="Agent" class="agent-icon" />
-            <span>{{ msg.from }}</span>
+  <div>
+    <nav class="top-nav">
+      <button @click="current = 'chat'">Chat</button>
+      <button @click="current = 'dashboard'">Dashboard</button>
+    </nav>
+    <Dashboard v-if="current === 'dashboard'" />
+    <div v-else class="chat-container">
+      <h1>Multi-Agent Chat</h1>
+      <div class="messages">
+        <div
+          v-for="msg in messages"
+          :key="msg.id"
+          :class="['message', msg.from === 'user' ? 'user' : 'agent']"
+        >
+          <div v-if="msg.from !== 'user'" class="bubble agent">
+            <div class="agent-header">
+              <img :src="`/${msg.from}.svg`" alt="Agent" class="agent-icon" />
+              <span>{{ msg.from }}</span>
+            </div>
+            <div class="agent-content" v-html="renderMarkdown(msg.text)"></div>
           </div>
-          <div class="agent-content" v-html="renderMarkdown(msg.text)"></div>
-        </div>
-        <div v-else class="bubble user">
-          <div class="user-content">{{ msg.text }}</div>
+          <div v-else class="bubble user">
+            <div class="user-content">{{ msg.text }}</div>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="input-area">
-      <input
-        type="text"
-        v-model="input"
-        @keyup.enter="sendMessage"
-        placeholder="Type a message or attach Excel..."
-      />
-      <button class="attach" @click="$refs.fileInput.click()">Attach</button>
-      <input
-        type="file"
-        ref="fileInput"
-        accept=".xlsx,.xls"
-        style="display:none"
-        @change="onFileChange"
-      />
-      <button class="send" @click="sendMessage">Send</button>
+      <div class="input-area">
+        <input
+          type="text"
+          v-model="input"
+          @keyup.enter="sendMessage"
+          placeholder="Type a message or attach Excel..."
+        />
+        <button class="attach" @click="$refs.fileInput.click()">Attach</button>
+        <input
+          type="file"
+          ref="fileInput"
+          accept=".xlsx,.xls"
+          style="display:none"
+          @change="onFileChange"
+        />
+        <button class="send" @click="sendMessage">Send</button>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import { marked } from 'marked'
+import Dashboard from './components/Dashboard.vue'
 
 export default {
+  components: { Dashboard },
   data() {
     return {
+      current: 'chat',
       input: '',
       messages: [],
       showExcelIcon: false,
@@ -111,23 +121,108 @@ export default {
 }
 </script>
 
-<<<<<<< HEAD
-<style>
-/* カスタムスクロールバー */
-.space-y-4::-webkit-scrollbar {
+<style scoped>
+.top-nav {
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  background: #eee;
+  margin-bottom: 10px;
+}
+.top-nav button {
+  padding: 6px 12px;
+}
+/* Existing chat styles follow */
+.chat-container {
+  max-width: 800px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+.chat-container h1 {
+  font-size: 2rem;
+  margin-bottom: 20px;
+  text-align: center;
+  color: #3f51b5;
+}
+.messages {
+  height: 600px;
+  overflow-y: auto;
+  margin-bottom: 20px;
+}
+.messages::-webkit-scrollbar {
   width: 8px;
 }
-.space-y-4::-webkit-scrollbar-thumb {
+.messages::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.2);
   border-radius: 4px;
 }
-
-/* Tailwind Prose を有効化する場合 */
-@import "https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/base.min.css";
-@import "https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/components.min.css";
-@import "https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/utilities.min.css";
+.message {
+  display: flex;
+  margin-bottom: 16px;
+}
+.message.agent {
+  justify-content: flex-start;
+}
+.message.user {
+  justify-content: flex-end;
+}
+.bubble {
+  max-width: 70%;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+.bubble.agent {
+  background: #e8eaf6;
+  color: #000;
+}
+.bubble.user {
+  background: #4caf50;
+  color: #fff;
+}
+.agent-header {
+  display: flex;
+  align-items: center;
+  background: #3f51b5;
+  color: #fff;
+  padding: 4px 8px;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+.agent-icon {
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
+  border-radius: 50%;
+}
+.agent-content,
+.user-content {
+  padding: 8px;
+}
+.input-area {
+  display: flex;
+  align-items: center;
+}
+.input-area input[type="text"] {
+  flex-grow: 1;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.input-area button {
+  margin-left: 8px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+}
+.input-area button.attach {
+  background: #ffc107;
+}
+.input-area button.send {
+  background: #2196f3;
+}
 </style>
-=======
-<style scoped>
-</style>
->>>>>>> 11169b6f4abdde79ac9f26e0186dadc485cd3c4d

--- a/flask-vue-multiagent-demo/frontend/src/components/ChartCard.vue
+++ b/flask-vue-multiagent-demo/frontend/src/components/ChartCard.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="chart-card">
+    <canvas ref="canvas" width="200" height="40"></canvas>
+  </div>
+</template>
+
+<script>
+import { onMounted, ref } from 'vue'
+export default {
+  props: {
+    chartData: Number
+  },
+  setup(props) {
+    const canvas = ref(null)
+    onMounted(() => {
+      if (canvas.value) {
+        const ctx = canvas.value.getContext('2d')
+        ctx.fillStyle = '#4caf50'
+        const width = Math.min(props.chartData || 0, 100) * 2
+        ctx.fillRect(0, 0, width, 40)
+      }
+    })
+    return { canvas }
+  }
+}
+</script>
+
+<style scoped>
+.chart-card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+</style>

--- a/flask-vue-multiagent-demo/frontend/src/components/Dashboard.vue
+++ b/flask-vue-multiagent-demo/frontend/src/components/Dashboard.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="dashboard">
+    <Sidebar />
+    <div class="content">
+      <div class="stats">
+        <StatCard title="Users" :value="123" />
+        <StatCard title="Sales" :value="456" />
+      </div>
+      <ChartCard :chartData="75" />
+    </div>
+  </div>
+</template>
+
+<script>
+import Sidebar from './Sidebar.vue'
+import StatCard from './StatCard.vue'
+import ChartCard from './ChartCard.vue'
+
+export default {
+  components: { Sidebar, StatCard, ChartCard }
+}
+</script>
+
+<style scoped>
+.dashboard {
+  display: flex;
+}
+.content {
+  flex: 1;
+  padding: 20px;
+}
+.stats {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+</style>

--- a/flask-vue-multiagent-demo/frontend/src/components/Sidebar.vue
+++ b/flask-vue-multiagent-demo/frontend/src/components/Sidebar.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="sidebar">
+    <img src="../assets/logo.png" alt="Logo" class="logo" />
+    <ul>
+      <li>Home</li>
+      <li>Analytics</li>
+      <li>Settings</li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style scoped>
+.sidebar {
+  width: 200px;
+  background: #333;
+  color: #fff;
+  min-height: 100vh;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.logo {
+  width: 100%;
+  margin-bottom: 20px;
+}
+ul {
+  list-style: none;
+  padding: 0;
+}
+li {
+  margin-bottom: 10px;
+  cursor: pointer;
+}
+</style>

--- a/flask-vue-multiagent-demo/frontend/src/components/StatCard.vue
+++ b/flask-vue-multiagent-demo/frontend/src/components/StatCard.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="stat-card">
+    <h3>{{ title }}</h3>
+    <p>{{ value }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: String,
+    value: [String, Number]
+  }
+}
+</script>
+
+<style scoped>
+.stat-card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.stat-card h3 {
+  margin: 0 0 8px;
+}
+</style>

--- a/flask-vue-multiagent-demo/frontend/src/main.js
+++ b/flask-vue-multiagent-demo/frontend/src/main.js
@@ -1,29 +1,4 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 
-<<<<<<< HEAD
-// Vuetify関係のインポート
-import 'vuetify/styles'
-import { createVuetify } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
-
-
-const app = createApp(App)
-
-import('https://cdn.jsdelivr.net/npm/vuetify@3/dist/vuetify.esm.js')
-  .then(({ createVuetify }) => {
-    const vuetify = createVuetify({
-  components,
-  directives,
-})
-    app.use(vuetify)
-    app.mount('#app')
-  })
-  .catch(() => {
-    app.mount('#app')
-  })
-=======
 createApp(App).mount('#app')
-
->>>>>>> 11169b6f4abdde79ac9f26e0186dadc485cd3c4d


### PR DESCRIPTION
## Summary
- add dashboard components (Sidebar, StatCard, ChartCard)
- integrate Dashboard into App.vue with toggle navigation
- clean up main.js
- add placeholder logo asset

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*