### PR TITLE
Add Vue dashboard with Vuetify

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,19 @@
+<template>
+  <v-app>
+    <Sidebar />
+    <Navbar />
+    <v-main>
+      <router-view />
+    </v-main>
+  </v-app>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import Sidebar from './components/Sidebar.vue'
+import Navbar from './components/Navbar.vue'
+
+export default defineComponent({
+  components: { Sidebar, Navbar }
+})
+</script>

--- a/src/components/ChartCard.vue
+++ b/src/components/ChartCard.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-card>
+    <v-card-title :style="{ backgroundColor: color, color: '#fff' }">
+      {{ title }}
+    </v-card-title>
+    <v-card-text>
+      <canvas ref="canvas"></canvas>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue'
+import { Chart, ChartData, ChartOptions } from 'chart.js'
+
+export default defineComponent({
+  name: 'ChartCard',
+  props: {
+    title: { type: String, required: true },
+    chartType: { type: String as () => 'line' | 'bar', required: true },
+    chartData: { type: Object as () => ChartData, required: true },
+    chartOptions: { type: Object as () => ChartOptions, required: true },
+    color: { type: String, required: true }
+  },
+  setup(props) {
+    const canvas = ref<HTMLCanvasElement | null>(null)
+
+    onMounted(() => {
+      if (canvas.value) {
+        new Chart(canvas.value, {
+          type: props.chartType,
+          data: props.chartData,
+          options: props.chartOptions
+        })
+      }
+    })
+
+    return { canvas }
+  }
+})
+</script>

--- a/src/components/EmployeeTable.vue
+++ b/src/components/EmployeeTable.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-card>
+    <v-data-table :headers="headers" :items="items" class="elevation-1" />
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'EmployeeTable',
+  props: {
+    items: {
+      type: Array as () => Array<{ id: number | string; name: string; salary: string; country: string; city: string }>,
+      required: true
+    }
+  },
+  setup() {
+    const headers = [
+      { text: 'ID', value: 'id' },
+      { text: 'Name', value: 'name' },
+      { text: 'Salary', value: 'salary' },
+      { text: 'Country', value: 'country' },
+      { text: 'City', value: 'city' }
+    ]
+    return { headers }
+  }
+})
+</script>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-app-bar app>
+    <v-app-bar-nav-icon />
+    <v-toolbar-title>Dashboard</v-toolbar-title>
+    <v-spacer />
+    <v-text-field
+      solo
+      flat
+      hide-details
+      prepend-inner-icon="mdi-magnify"
+      label="Search"
+    />
+    <v-btn icon>
+      <v-badge color="red" content="4" overlap>
+        <v-icon>mdi-account-circle</v-icon>
+      </v-badge>
+    </v-btn>
+  </v-app-bar>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'Navbar'
+})
+</script>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-navigation-drawer app permanent>
+    <v-list>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title class="text-h6">My App</v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+      <v-divider></v-divider>
+      <v-list-item v-for="item in items" :key="item.title" link>
+        <v-list-item-icon><v-icon>{{ item.icon }}</v-icon></v-list-item-icon>
+        <v-list-item-content><v-list-item-title>{{ item.title }}</v-list-item-title></v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </v-navigation-drawer>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'Sidebar',
+  setup() {
+    const items = [
+      { title: 'Dashboard', icon: 'mdi-view-dashboard' },
+      { title: 'User Profile', icon: 'mdi-account' },
+      { title: 'Table List', icon: 'mdi-table' },
+      { title: 'Typography', icon: 'mdi-format-size' },
+      { title: 'Icons', icon: 'mdi-emoticon' },
+      { title: 'Maps', icon: 'mdi-map' },
+      { title: 'Notifications', icon: 'mdi-bell' }
+    ]
+    return { items }
+  }
+})
+</script>

--- a/src/components/StatCard.vue
+++ b/src/components/StatCard.vue
@@ -1,0 +1,28 @@
+<template>
+  <v-card class="pa-4">
+    <div class="d-flex align-center">
+      <v-avatar size="40" class="mr-4" color="primary">
+        <v-icon dark>{{ icon }}</v-icon>
+      </v-avatar>
+      <div>
+        <div class="text-subtitle-1">{{ label }}</div>
+        <div class="text-h5 font-weight-bold">{{ value }}</div>
+      </div>
+    </div>
+    <v-card-text class="pt-2">{{ description }}</v-card-text>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'StatCard',
+  props: {
+    icon: { type: String, required: true },
+    label: { type: String, required: true },
+    value: { type: [String, Number], required: true },
+    description: { type: String, required: true }
+  }
+})
+</script>

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-card>
+    <v-list>
+      <v-list-item v-for="(task, i) in tasks" :key="i" :class="typeClass(task.type)">
+        <v-list-item-action>
+          <v-checkbox v-model="task.done" />
+        </v-list-item-action>
+        <v-list-item-content>
+          <v-list-item-title>{{ task.text }}</v-list-item-title>
+        </v-list-item-content>
+        <v-list-item-action class="d-flex">
+          <v-icon small class="mr-2">mdi-pencil</v-icon>
+          <v-icon small>mdi-close</v-icon>
+        </v-list-item-action>
+      </v-list-item>
+    </v-list>
+  </v-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'TaskList',
+  props: {
+    tasks: {
+      type: Array as () => Array<{ text: string; type: 'Bugs' | 'Website' | 'Server'; done?: boolean }>,
+      required: true
+    }
+  },
+  setup() {
+    const typeClass = (type: string) => {
+      if (type === 'Bugs') return 'red'
+      if (type === 'Website') return 'blue'
+      return 'green'
+    }
+    return { typeClass }
+  }
+})
+</script>
+
+<style scoped>
+.red .v-icon {
+  color: red;
+}
+.blue .v-icon {
+  color: blue;
+}
+.green .v-icon {
+  color: green;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+import vuetify from './plugins/vuetify'
+
+createApp(App).use(router).use(vuetify).mount('#app')

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,0 +1,6 @@
+import Vuetify from 'vuetify/lib'
+import 'vuetify/dist/vuetify.min.css'
+
+export default new Vuetify({
+  theme: { options: { customProperties: true } }
+})

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,13 @@
+import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
+import DashboardView from './views/DashboardView.vue'
+
+const routes: Array<RouteRecordRaw> = [
+  { path: '/', name: 'Dashboard', component: DashboardView }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,0 +1,129 @@
+<template>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12" md="4">
+        <ChartCard
+          title="Daily Sales"
+          chartType="line"
+          :chartData="dailySalesData"
+          :chartOptions="chartOptions"
+          color="#00bcd4"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <ChartCard
+          title="Email Subscription"
+          chartType="bar"
+          :chartData="emailData"
+          :chartOptions="chartOptions"
+          color="#f44336"
+        />
+      </v-col>
+      <v-col cols="12" md="4">
+        <ChartCard
+          title="Completed Tasks"
+          chartType="line"
+          :chartData="tasksData"
+          :chartOptions="chartOptions"
+          color="#4caf50"
+        />
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col cols="12" md="3">
+        <StatCard icon="mdi-chart-bar" label="Revenue" value="$34,245" description="Last 24 Hours" />
+      </v-col>
+      <v-col cols="12" md="3">
+        <StatCard icon="mdi-database" label="Used Space" value="49/50 GB" description="Get More Space" />
+      </v-col>
+      <v-col cols="12" md="3">
+        <StatCard icon="mdi-alert-circle" label="Fixed Issues" value="75" description="Tracked from GitHub" />
+      </v-col>
+      <v-col cols="12" md="3">
+        <StatCard icon="mdi-twitter" label="Followers" value="+245" description="Just Updated" />
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col cols="12">
+        <EmployeeTable :items="employees" />
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col cols="12">
+        <TaskList :tasks="tasks" />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import ChartCard from '../components/ChartCard.vue'
+import StatCard from '../components/StatCard.vue'
+import EmployeeTable from '../components/EmployeeTable.vue'
+import TaskList from '../components/TaskList.vue'
+import { ChartData, ChartOptions } from 'chart.js'
+
+export default defineComponent({
+  name: 'DashboardView',
+  components: { ChartCard, StatCard, EmployeeTable, TaskList },
+  setup() {
+    const chartOptions: ChartOptions = { responsive: true, maintainAspectRatio: false }
+
+    const dailySalesData: ChartData = {
+      labels: ['M', 'T', 'W', 'T', 'F', 'S', 'S'],
+      datasets: [
+        {
+          label: 'Sales',
+          data: [12, 17, 7, 17, 23, 18, 38],
+          borderColor: '#fff',
+          backgroundColor: 'rgba(255,255,255,0.5)',
+          fill: false
+        }
+      ]
+    }
+
+    const emailData: ChartData = {
+      labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      datasets: [
+        {
+          label: 'Subscriptions',
+          data: [5, 20, 36, 10, 10, 20, 30, 40, 50, 60, 70, 80],
+          backgroundColor: 'rgba(255,255,255,0.5)'
+        }
+      ]
+    }
+
+    const tasksData: ChartData = {
+      labels: ['12am', '3am', '6am', '9am', '12pm', '3pm', '6pm', '9pm'],
+      datasets: [
+        {
+          label: 'Tasks',
+          data: [230, 750, 450, 300, 280, 240, 200, 190],
+          borderColor: '#fff',
+          backgroundColor: 'rgba(255,255,255,0.5)',
+          fill: false
+        }
+      ]
+    }
+
+    const employees = [
+      { id: 1, name: 'Dakota Rice', salary: '$36,738', country: 'Niger', city: 'Oud-Turnhout' },
+      { id: 2, name: 'Minerva Hooper', salary: '$23,789', country: 'Curaçao', city: 'Sinaai-Waas' },
+      { id: 3, name: 'Sage Rodriguez', salary: '$56,142', country: 'Netherlands', city: 'Baileux' },
+      { id: 4, name: 'Philip Chaney', salary: '$38,735', country: 'Korea, South', city: 'Overland Park' }
+    ]
+
+    const tasks = [
+      { text: 'Sign contract for what?', type: 'Bugs' },
+      { text: 'Create new landing page', type: 'Website' },
+      { text: 'Update server configuration', type: 'Server' }
+    ]
+
+    return { chartOptions, dailySalesData, emailData, tasksData, employees, tasks }
+  }
+})
+</script>


### PR DESCRIPTION
## Summary
- add Vue 3 main entry with Vuetify plugin and router
- configure Vuetify plugin
- provide router with dashboard route
- build app shell with sidebar and navbar
- add dashboard components: stat cards, chart card, employee table, task list
- create dashboard view with sample data

## Testing
- `git status --short`
- `git log -1 --stat`